### PR TITLE
Actually commit the images and push them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,15 @@ script:
   - molecule verify
   - cd $TRAVIS_BUILD_DIR
 after_success:
-  - docker commit `docker ps |grep "centos:7" |awk {'print $1'}` quay.io/egi/voms-client
+  - docker commit voms-clients-centos6
+  - docker commit voms-clients-centos7
+  - docker tag voms-clients-centos6 quay.io/egi/voms-client:centos6
+  - docker tag voms-clients-centos7 quay.io/egi/voms-client:centos7
+  - docker tag voms-clients-centos7 quay.io/egi/voms-client:latest
   - docker login -u="egi+packerbot" -p="$QUAY_PASSWORD" quay.io
-  - docker push quay.io/egi/voms-client
+  - docker push quay.io/egi/voms-client:centos6
+  - docker push quay.io/egi/voms-client:centos7
+  - docker push quay.io/egi/voms-client:latest
 after_failure:
 before_deploy:
 deploy:


### PR DESCRIPTION
# **Related issue** #18 #17 

## Short summary of changes

The images were not pushed to quay after the build. This properly tags and pushes them.